### PR TITLE
Use `ei.h` header instead of `erl_interface.h`

### DIFF
--- a/c_src/dnssd.c
+++ b/c_src/dnssd.c
@@ -23,7 +23,7 @@
 #endif
 
 #include <erl_driver.h>
-#include <erl_interface.h>
+#include <ei.h>
 #include <string.h>
 #include <dns_sd.h>
 


### PR DESCRIPTION
`erl_interface.h` has been deprecated in OTP 23.

fixes #3